### PR TITLE
Add standalone web demo

### DIFF
--- a/standalone/docs/index.html
+++ b/standalone/docs/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Iris - Standalone Demo</title>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Project Iris</h1>
+            <p class="subtitle">Core 5-Emotion Neurochemical Explorer</p>
+        </div>
+
+        <div class="controls">
+            <div class="slider-group">
+                <div class="slider-label">
+                    <span class="chemical-name">Dopamine</span>
+                    <span class="slider-value" id="dopamine-value">50</span>
+                </div>
+                <input type="range" id="dopamine" class="slider" min="0" max="100" value="50">
+            </div>
+
+            <div class="slider-group">
+                <div class="slider-label">
+                    <span class="chemical-name">Serotonin</span>
+                    <span class="slider-value" id="serotonin-value">50</span>
+                </div>
+                <input type="range" id="serotonin" class="slider" min="0" max="100" value="50">
+            </div>
+
+            <div class="slider-group">
+                <div class="slider-label">
+                    <span class="chemical-name">Oxytocin</span>
+                    <span class="slider-value" id="oxytocin-value">50</span>
+                </div>
+                <input type="range" id="oxytocin" class="slider" min="0" max="100" value="50">
+            </div>
+
+            <div class="slider-group">
+                <div class="slider-label">
+                    <span class="chemical-name">Cortisol</span>
+                    <span class="slider-value" id="cortisol-value">50</span>
+                </div>
+                <input type="range" id="cortisol" class="slider" min="0" max="100" value="50">
+            </div>
+
+            <div class="slider-group">
+                <div class="slider-label">
+                    <span class="chemical-name">Norepinephrine</span>
+                    <span class="slider-value" id="norepinephrine-value">50</span>
+                </div>
+                <input type="range" id="norepinephrine" class="slider" min="0" max="100" value="50">
+            </div>
+        </div>
+
+        <div class="results">
+            <div class="emotion-display">
+                <div class="emotion-name" id="emotion-name">—</div>
+                <div class="emotion-description" id="emotion-description">Adjust the sliders to infer an emotion.</div>
+                <div class="confidence-score" id="confidence-score">Confidence: --</div>
+            </div>
+
+            <div class="visualization-container">
+                <h3 class="viz-title">Valence-Arousal Emotion Space</h3>
+                <svg id="emotion-canvas" viewBox="0 0 600 500">
+                    <defs>
+                        <pattern id="grid" width="60" height="50" patternUnits="userSpaceOnUse">
+                            <path d="M 60 0 L 0 0 0 50" fill="none" class="grid-line"/>
+                        </pattern>
+                    </defs>
+                    <rect width="100%" height="100%" fill="url(#grid)" opacity="0.3"/>
+                    <line x1="60" y1="450" x2="540" y2="450" class="axis-line"/>
+                    <line x1="60" y1="50" x2="60" y2="450" class="axis-line"/>
+                    <text x="60" y="470" class="axis-label" text-anchor="middle">Unpleasant</text>
+                    <text x="540" y="470" class="axis-label" text-anchor="middle">Pleasant</text>
+                    <text x="300" y="490" class="axis-label" text-anchor="middle">Valence</text>
+                    <text x="45" y="455" class="axis-label" text-anchor="end">Calm</text>
+                    <text x="45" y="55" class="axis-label" text-anchor="end">Intense</text>
+                    <text x="30" y="250" class="axis-label" text-anchor="middle" transform="rotate(-90, 30, 250)">Arousal</text>
+                    <text x="150" y="120" class="quadrant-label">Stress</text>
+                    <text x="450" y="120" class="quadrant-label">Excitement</text>
+                    <text x="150" y="380" class="quadrant-label">Depression</text>
+                    <text x="450" y="380" class="quadrant-label">Contentment</text>
+                    <circle id="emotion-dot" class="emotion-dot" r="12" cx="300" cy="250"/>
+                    <text id="emotion-label" class="emotion-label" x="300" y="235">Adjust Sliders</text>
+                </svg>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { emotionCoords, canvasConfig, plotDimensions } from './js/emotionCoords.js';
+        import { updateEmotionDot, coordsToSVG, initializeEmotionDot } from './js/updateEmotionDot.js';
+        import { inferEmotion } from './js/inference.js';
+
+        function updateEmotionVisualizationInternal(emotion) {
+            if (!emotionCoords[emotion]) return;
+            const coords = emotionCoords[emotion];
+            const svgCoords = coordsToSVG(coords.valence, coords.arousal);
+            const dot = document.getElementById('emotion-dot');
+            const label = document.getElementById('emotion-label');
+            if (!dot || !label) return;
+            dot.setAttribute('cx', svgCoords.x);
+            dot.setAttribute('cy', svgCoords.y);
+            label.setAttribute('x', svgCoords.x);
+            label.setAttribute('y', svgCoords.y - 20);
+            label.textContent = emotion.charAt(0).toUpperCase() + emotion.slice(1);
+        }
+
+        const sliders = {
+            dopamine: document.getElementById('dopamine'),
+            serotonin: document.getElementById('serotonin'),
+            oxytocin: document.getElementById('oxytocin'),
+            cortisol: document.getElementById('cortisol'),
+            norepinephrine: document.getElementById('norepinephrine')
+        };
+
+        const valueDisplays = {
+            dopamine: document.getElementById('dopamine-value'),
+            serotonin: document.getElementById('serotonin-value'),
+            oxytocin: document.getElementById('oxytocin-value'),
+            cortisol: document.getElementById('cortisol-value'),
+            norepinephrine: document.getElementById('norepinephrine-value')
+        };
+
+        const emotionNameEl = document.getElementById('emotion-name');
+        const emotionDescriptionEl = document.getElementById('emotion-description');
+        const confidenceScoreEl = document.getElementById('confidence-score');
+
+        function updateEmotionDisplay() {
+            const payload = {
+                dopamine: parseFloat(sliders.dopamine.value),
+                serotonin: parseFloat(sliders.serotonin.value),
+                oxytocin: parseFloat(sliders.oxytocin.value),
+                cortisol: parseFloat(sliders.cortisol.value),
+                norepinephrine: parseFloat(sliders.norepinephrine.value)
+            };
+
+            Object.keys(valueDisplays).forEach(key => {
+                valueDisplays[key].textContent = sliders[key].value;
+            });
+
+            const result = inferEmotion(payload);
+            if (result.emotion) {
+                emotionNameEl.textContent = result.emotion;
+                confidenceScoreEl.textContent = `Confidence: ${(result.confidence * 100).toFixed(0)}%`;
+                emotionDescriptionEl.textContent = result.description;
+                updateEmotionVisualizationInternal(result.emotion);
+            } else {
+                emotionNameEl.textContent = 'N/A';
+                emotionDescriptionEl.textContent = 'Adjust the sliders to infer an emotion.';
+                confidenceScoreEl.textContent = '';
+                initializeEmotionDot();
+            }
+        }
+
+        Object.keys(sliders).forEach(key => {
+            sliders[key].addEventListener('input', updateEmotionDisplay);
+        });
+
+        initializeEmotionDot();
+        updateEmotionDisplay();
+    </script>
+</body>
+</html>

--- a/standalone/docs/js/emotionCoords.js
+++ b/standalone/docs/js/emotionCoords.js
@@ -1,0 +1,70 @@
+/**
+ * Project Iris - Enhanced Emotion Coordinate Mapping
+ * Defines the valence-arousal coordinates for each core emotion with rich metadata
+ */
+
+// Enhanced emotion coordinate mapping with descriptions and quadrant info
+export const emotionCoords = {
+    happiness: { 
+        valence: 0.9, 
+        arousal: 0.85, 
+        description: "High energy, positive state",
+        quadrant: "Excitement"
+    },
+    anger: { 
+        valence: 0.2, 
+        arousal: 0.9, 
+        description: "High energy, negative state",
+        quadrant: "Stress"
+    },
+    sadness: { 
+        valence: 0.25, 
+        arousal: 0.3, 
+        description: "Low energy, negative state",
+        quadrant: "Depression"
+    },
+    fear: { 
+        valence: 0.15, 
+        arousal: 0.8, 
+        description: "High alertness, threat response",
+        quadrant: "Stress"
+    },
+    disgust: { 
+        valence: 0.2, 
+        arousal: 0.45, 
+        description: "Low-moderate energy, aversive",
+        quadrant: "Depression"
+    }
+};
+
+// Quadrant definitions for emotional interpretation
+export const emotionQuadrants = {
+    'high-valence-high-arousal': 'Excitement',
+    'low-valence-high-arousal': 'Stress',
+    'low-valence-low-arousal': 'Depression',
+    'high-valence-low-arousal': 'Contentment'
+};
+
+// Determine which quadrant an emotion falls into
+export function getEmotionQuadrant(valence, arousal) {
+    const isHighValence = valence > 0.5;
+    const isHighArousal = arousal > 0.5;
+    
+    if (isHighValence && isHighArousal) return 'Excitement';
+    if (!isHighValence && isHighArousal) return 'Stress';
+    if (!isHighValence && !isHighArousal) return 'Depression';
+    return 'Contentment';
+}
+
+// Canvas configuration for SVG visualization
+export const canvasConfig = {
+    width: 600,
+    height: 500,
+    margin: { left: 60, right: 60, top: 50, bottom: 50 }
+};
+
+// Calculate plot dimensions
+export const plotDimensions = {
+    width: canvasConfig.width - canvasConfig.margin.left - canvasConfig.margin.right,
+    height: canvasConfig.height - canvasConfig.margin.top - canvasConfig.margin.bottom
+};

--- a/standalone/docs/js/inference.js
+++ b/standalone/docs/js/inference.js
@@ -1,0 +1,73 @@
+export const emotionData = [
+    {
+        emotion: 'happiness',
+        dopamine: 80,
+        serotonin: 70,
+        oxytocin: 60,
+        cortisol: 10,
+        norepinephrine: 40,
+        description: 'A state of joy, contentment, and positivity.'
+    },
+    {
+        emotion: 'anger',
+        dopamine: 30,
+        serotonin: 20,
+        oxytocin: 10,
+        cortisol: 70,
+        norepinephrine: 90,
+        description: 'A surge of intensity often tied to injustice or frustration.'
+    },
+    {
+        emotion: 'sadness',
+        dopamine: 20,
+        serotonin: 30,
+        oxytocin: 25,
+        cortisol: 60,
+        norepinephrine: 20,
+        description: 'A deep emotional state of loss, reflection, or hurt.'
+    },
+    {
+        emotion: 'fear',
+        dopamine: 15,
+        serotonin: 10,
+        oxytocin: 5,
+        cortisol: 80,
+        norepinephrine: 80,
+        description: 'A heightened alertness in the face of perceived danger.'
+    },
+    {
+        emotion: 'disgust',
+        dopamine: 10,
+        serotonin: 25,
+        oxytocin: 5,
+        cortisol: 50,
+        norepinephrine: 15,
+        description: 'A visceral rejection of something repulsive or wrong.'
+    }
+];
+
+// Keys in neurotransmitter vector
+const CHEM_KEYS = ['dopamine', 'serotonin', 'oxytocin', 'cortisol', 'norepinephrine'];
+
+export function inferEmotion(values) {
+    // values: {dopamine: num, serotonin: num, ...}
+    const inputVec = CHEM_KEYS.map(k => values[k] || 0);
+    const vecNorm = Math.hypot(...inputVec);
+    if (vecNorm === 0) {
+        return { emotion: null, confidence: 0 };
+    }
+
+    let best = null;
+    let bestSim = -1;
+    for (const row of emotionData) {
+        const rowVec = CHEM_KEYS.map(k => row[k]);
+        const rowNorm = Math.hypot(...rowVec);
+        const dot = rowVec.reduce((sum, val, idx) => sum + val * inputVec[idx], 0);
+        const sim = dot / (rowNorm * vecNorm);
+        if (sim > bestSim) {
+            bestSim = sim;
+            best = row;
+        }
+    }
+    return { emotion: best.emotion, confidence: bestSim, description: best.description };
+}

--- a/standalone/docs/js/updateEmotionDot.js
+++ b/standalone/docs/js/updateEmotionDot.js
@@ -1,0 +1,151 @@
+/**
+ * Project Iris - Enhanced Emotion Dot Visualization
+ * Handles smooth 2D emotion visualization with SVG animations
+ */
+
+import { emotionCoords, canvasConfig, plotDimensions, getEmotionQuadrant } from './emotionCoords.js';
+
+// Animation configuration
+const animationConfig = {
+    duration: '0.8s',
+    easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    glowIntensity: 10
+};
+
+// Convert valence/arousal coordinates to SVG pixel coordinates
+export function coordsToSVG(valence, arousal) {
+    const x = canvasConfig.margin.left + (valence * plotDimensions.width);
+    const y = canvasConfig.margin.top + ((1 - arousal) * plotDimensions.height); // Flip Y axis
+    return { x, y };
+}
+
+// Main emotion dot update function with enhanced features
+export function updateEmotionDot(emotionName) {
+    const emotionData = emotionCoords[emotionName];
+
+    if (!emotionData) {
+        console.warn(`No coordinates found for emotion: ${emotionName}`);
+        return;
+    }
+
+    const coords = emotionData;
+    const svgCoords = coordsToSVG(coords.valence, coords.arousal);
+    
+    // Get DOM elements
+    const dot = document.getElementById('emotion-dot');
+    const label = document.getElementById('emotion-label');
+    
+    if (!dot || !label) {
+        console.warn('Emotion visualization elements not found');
+        return;
+    }
+
+    // Update dot position with smooth animation
+    dot.setAttribute('cx', svgCoords.x);
+    dot.setAttribute('cy', svgCoords.y);
+    
+    // Update label position and text
+    label.setAttribute('x', svgCoords.x);
+    label.setAttribute('y', svgCoords.y - 20);
+    label.textContent = emotionName.charAt(0).toUpperCase() + emotionName.slice(1);
+    
+    // Add enhanced visual feedback
+    updateDotVisualFeedback(dot, emotionData);
+    
+    // Log for debugging
+    console.log(`🎯 Updated emotion visualization: ${emotionName} → [${coords.valence.toFixed(2)}, ${coords.arousal.toFixed(2)}] (${emotionData.quadrant})`);
+}
+
+// Enhanced visual feedback for emotion transitions
+function updateDotVisualFeedback(dot, emotionData) {
+    // Update dot color based on quadrant
+    const quadrantColors = {
+        'Excitement': '#00FFE0',     // Cyan for positive high-arousal
+        'Stress': '#FF6B6B',         // Red for negative high-arousal  
+        'Depression': '#6B73FF',     // Blue for negative low-arousal
+        'Contentment': '#4ECDC4'     // Teal for positive low-arousal
+    };
+    
+    const color = quadrantColors[emotionData.quadrant] || '#00FFE0';
+    dot.setAttribute('fill', color);
+    dot.style.filter = `drop-shadow(0 0 ${animationConfig.glowIntensity}px ${color})`;
+}
+
+// Global function for external integration (matches emotion_dot_visualization.html API)
+export function updateEmotionVisualization(emotion) {
+    return updateEmotionDot(emotion);
+}
+
+// Initialize dot in center position
+export function initializeEmotionDot() {
+    const dot = document.getElementById('emotion-dot');
+    const label = document.getElementById('emotion-label');
+    
+    if (dot && label) {
+        // Center position
+        const centerX = canvasConfig.width / 2;
+        const centerY = canvasConfig.height / 2;
+        
+        dot.setAttribute('cx', centerX);
+        dot.setAttribute('cy', centerY);
+        label.setAttribute('x', centerX);
+        label.setAttribute('y', centerY - 20);
+        label.textContent = 'Adjust Sliders';
+    }
+}
+
+// Utility function to simulate emotion transitions for testing
+export function simulateEmotionInference(emotion) {
+    const emotionData = emotionCoords[emotion];
+    if (!emotionData) return null;
+    
+    return {
+        emotion: emotion,
+        confidence: Math.random() * 0.3 + 0.7, // 0.7-1.0
+        description: emotionData.description,
+        quadrant: emotionData.quadrant,
+        coordinates: {
+            valence: emotionData.valence,
+            arousal: emotionData.arousal
+        }
+    };
+}
+
+// Auto-demo functionality for testing
+export function startEmotionDemo() {
+    const emotions = Object.keys(emotionCoords);
+    let index = 0;
+    
+    const demoInterval = setInterval(() => {
+        updateEmotionDot(emotions[index]);
+        console.log(`🎭 Demo: Showing ${emotions[index]}`);
+        index = (index + 1) % emotions.length;
+    }, 3000);
+    
+    // Return interval ID so it can be stopped
+    return demoInterval;
+}
+
+// Make functions available globally for integration
+if (typeof window !== 'undefined') {
+    window.updateEmotionVisualization = updateEmotionVisualization;
+    window.updateEmotionDot = updateEmotionDot;
+    window.coordsToSVG = coordsToSVG;
+    window.initializeEmotionDot = initializeEmotionDot;
+}EmotionDot.js
+
+import { emotionCoords } from './emotionCoords.js';
+
+// Temporary: just logs movement — Claude's canvas code will call this later
+export function updateEmotionDot(emotionName) {
+  const coords = emotionCoords[emotionName];
+
+  if (!coords) {
+    console.warn(`No coordinates found for emotion: ${emotionName}`);
+    return;
+  }
+
+  console.log(`→ Move dot to: [valence: ${coords.valence}, arousal: ${coords.arousal}]`);
+  // Future: This is where Claude’s visualization hook will go:
+  // moveDotTo(coords.valence, coords.arousal);
+}

--- a/standalone/docs/styles.css
+++ b/standalone/docs/styles.css
@@ -1,0 +1,364 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inter', sans-serif;
+    background: linear-gradient(135deg, #0a0a0f 0%, #1a1a2e 50%, #16213e 100%);
+    color: #e0e0e0;
+    min-height: 100vh;
+    padding: 20px;
+    overflow-x: hidden;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+    align-items: center;
+    min-height: calc(100vh - 40px);
+}
+
+.header {
+    grid-column: 1 / -1;
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+h1 {
+    font-family: 'Cinzel', serif;
+    font-size: 2.5rem;
+    font-weight: 600;
+    background: linear-gradient(45deg, #64ffda, #bb86fc, #cf6679);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 10px;
+    text-shadow: 0 0 30px rgba(100, 255, 218, 0.3);
+}
+
+.subtitle {
+    font-size: 1.1rem;
+    color: #a0a0a0;
+    font-weight: 300;
+}
+
+.controls {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 20px;
+    padding: 40px;
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.results {
+    text-align: center;
+    padding: 40px;
+}
+
+.slider-group {
+    margin-bottom: 30px;
+}
+
+.slider-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+    font-size: 1rem;
+    font-weight: 400;
+}
+
+.chemical-name {
+    color: #64ffda;
+    font-weight: 500;
+}
+
+.slider-value {
+    background: rgba(100, 255, 218, 0.2);
+    padding: 2px 8px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    min-width: 35px;
+    text-align: center;
+}
+
+.slider {
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    outline: none;
+    appearance: none;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.slider:hover {
+    box-shadow: 0 0 15px rgba(100, 255, 218, 0.4);
+}
+
+.slider::-webkit-slider-thumb {
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: linear-gradient(45deg, #64ffda, #bb86fc);
+    cursor: pointer;
+    box-shadow: 0 0 10px rgba(100, 255, 218, 0.5);
+    transition: all 0.2s ease;
+}
+
+.slider::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+    box-shadow: 0 0 20px rgba(100, 255, 218, 0.8);
+}
+
+.slider::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: linear-gradient(45deg, #64ffda, #bb86fc);
+    cursor: pointer;
+    border: none;
+    box-shadow: 0 0 10px rgba(100, 255, 218, 0.5);
+}
+
+.emotion-display {
+    margin-bottom: 40px;
+}
+
+.emotion-name {
+    font-family: 'Cinzel', serif;
+    font-size: 3rem;
+    font-weight: 600;
+    margin-bottom: 20px;
+    background: linear-gradient(45deg, #bb86fc, #64ffda, #cf6679);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-shadow: 0 0 40px rgba(187, 134, 252, 0.4);
+    animation: glow 2s ease-in-out infinite alternate;
+}
+
+@keyframes glow {
+    from { filter: brightness(1); }
+    to { filter: brightness(1.2); }
+}
+
+.emotion-description {
+    font-size: 1.2rem;
+    line-height: 1.6;
+    color: #c0c0c0;
+    margin-bottom: 25px;
+    max-width: 400px;
+    margin-left: auto;
+    margin-right: auto;
+    font-style: italic;
+    border-left: 4px solid rgba(255, 255, 255, 0.2);
+    padding-left: 12px;
+}
+
+.confidence-score {
+    font-size: 1rem;
+    color: #64ffda;
+    background: rgba(100, 255, 218, 0.1);
+    padding: 8px 16px;
+    border-radius: 12px;
+    display: inline-block;
+    border: 1px solid rgba(100, 255, 218, 0.3);
+    margin-bottom: 30px;
+}
+
+/* Enhanced Emotion Visualization Styles */
+.visualization-container {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 20px;
+    padding: 30px;
+    backdrop-filter: blur(15px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+    margin-top: 20px;
+    position: relative;
+    overflow: hidden;
+}
+
+.visualization-container::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(135deg, rgba(100, 255, 218, 0.05) 0%, rgba(187, 134, 252, 0.05) 100%);
+    pointer-events: none;
+    border-radius: 20px;
+}
+
+.viz-title {
+    font-family: 'Cinzel', serif;
+    font-size: 1.5rem;
+    font-weight: 600;
+    text-align: center;
+    margin-bottom: 20px;
+    background: linear-gradient(45deg, #00FFE0, #0080FF);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    position: relative;
+    z-index: 1;
+}
+
+#emotion-canvas {
+    width: 100%;
+    height: auto;
+    max-width: 600px;
+    margin: 0 auto;
+    display: block;
+    border-radius: 15px;
+    background: rgba(0, 0, 0, 0.3);
+    position: relative;
+    z-index: 1;
+}
+
+.axis-label {
+    font-size: 14px;
+    fill: #aaaaaa;
+    font-weight: 500;
+    font-family: 'Inter', sans-serif;
+}
+
+.grid-line {
+    stroke: #444444;
+    stroke-width: 1;
+    opacity: 0.5;
+}
+
+.axis-line {
+    stroke: #666666;
+    stroke-width: 2;
+}
+
+.emotion-dot {
+    fill: #00FFE0;
+    filter: drop-shadow(0 0 10px #00FFE0);
+    transition: cx 0.8s cubic-bezier(0.4, 0, 0.2, 1), 
+                cy 0.8s cubic-bezier(0.4, 0, 0.2, 1),
+                fill 0.3s ease,
+                filter 0.3s ease;
+    cursor: pointer;
+}
+
+.emotion-dot:hover {
+    filter: drop-shadow(0 0 15px currentColor);
+    r: 14;
+}
+
+.emotion-label {
+    fill: #00FFE0;
+    font-size: 16px;
+    font-weight: 600;
+    text-anchor: middle;
+    font-family: 'Inter', sans-serif;
+    transition: x 0.8s cubic-bezier(0.4, 0, 0.2, 1), 
+                y 0.8s cubic-bezier(0.4, 0, 0.2, 1),
+                fill 0.3s ease;
+    pointer-events: none;
+}
+
+.quadrant-label {
+    font-size: 12px;
+    fill: #888888;
+    font-weight: 500;
+    text-anchor: middle;
+    font-family: 'Inter', sans-serif;
+    opacity: 0.8;
+}
+
+/* Enhanced emotion controls for testing */
+.emotion-controls {
+    margin-top: 30px;
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.emotion-btn {
+    padding: 12px 24px;
+    background: rgba(0, 255, 224, 0.1);
+    border: 2px solid #00FFE0;
+    color: #00FFE0;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-weight: 500;
+    text-transform: capitalize;
+    font-family: 'Inter', sans-serif;
+    font-size: 14px;
+}
+
+.emotion-btn:hover {
+    background: rgba(0, 255, 224, 0.2);
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0, 255, 224, 0.3);
+}
+
+.emotion-btn.active {
+    background: #00FFE0;
+    color: #1e1e1e;
+    transform: translateY(-2px);
+}
+
+/* Quadrant-specific dot colors */
+.emotion-dot.excitement {
+    fill: #00FFE0;
+    filter: drop-shadow(0 0 10px #00FFE0);
+}
+
+.emotion-dot.stress {
+    fill: #FF6B6B;
+    filter: drop-shadow(0 0 10px #FF6B6B);
+}
+
+.emotion-dot.depression {
+    fill: #6B73FF;
+    filter: drop-shadow(0 0 10px #6B73FF);
+}
+
+.emotion-dot.contentment {
+    fill: #4ECDC4;
+    filter: drop-shadow(0 0 10px #4ECDC4);
+}
+
+@media (max-width: 768px) {
+    .container {
+        grid-template-columns: 1fr;
+        gap: 30px;
+    }
+    
+    h1 {
+        font-size: 2rem;
+    }
+    
+    .emotion-name {
+        font-size: 2.2rem;
+    }
+    
+    .controls {
+        padding: 30px;
+    }
+    
+    .visualization-container {
+        padding: 20px;
+    }
+    
+    .viz-title {
+        font-size: 1.2rem;
+    }
+}


### PR DESCRIPTION
## Summary
- create a standalone `docs` site under `standalone`
- implement client-side emotion inference in JS
- copy visualization scripts and styles from main docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e922e039483239d370a61f4941ba8